### PR TITLE
Patch Module errors 

### DIFF
--- a/lib/transifex/crud_requests.rb
+++ b/lib/transifex/crud_requests.rb
@@ -4,8 +4,8 @@ module Transifex
       def generate_url(object, params = {})
         class_name_string = object.class.name.split("::").last.downcase.to_s
         url = ""
-        if object.class.respond_to?(:parents)
-          object.class.parents.map{|parent| url += "/" + parent.to_s + "/" + object.instance_variable_get("@" + parent.to_s + "_slug")}                      
+        if object.class.respond_to?(:authors)
+          object.class.authors.map{|author| url += "/" + author.to_s + "/" + object.instance_variable_get("@" + author.to_s + "_slug")}                      
         end          
         url += "/" + class_name_string
         url += "/" + object.instance_variable_get("@" + class_name_string + "_slug") if object.instance_variable_defined?("@" + class_name_string + "_slug")

--- a/lib/transifex/project_components/language.rb
+++ b/lib/transifex/project_components/language.rb
@@ -14,7 +14,7 @@ module Transifex
         @language_slug = language_code
       end
 
-      def self.parents
+      def self.authors
         [:project]      
       end
 

--- a/lib/transifex/project_components/language_components/coordinators.rb
+++ b/lib/transifex/project_components/language_components/coordinators.rb
@@ -14,7 +14,7 @@ module Transifex
           @language_slug = language_code
         end
 
-        def self.parents
+        def self.authors
           [:project, :language]
         end
 

--- a/lib/transifex/project_components/language_components/reviewers.rb
+++ b/lib/transifex/project_components/language_components/reviewers.rb
@@ -14,7 +14,7 @@ module Transifex
           @language_slug = language_code
         end
 
-        def self.parents
+        def self.authors
           [:project, :language]
         end
 

--- a/lib/transifex/project_components/language_components/translators.rb
+++ b/lib/transifex/project_components/language_components/translators.rb
@@ -14,7 +14,7 @@ module Transifex
           @language_slug = language_code
         end
 
-        def self.parents
+        def self.authors
           [:project, :language]
         end
 

--- a/lib/transifex/project_components/languages.rb
+++ b/lib/transifex/project_components/languages.rb
@@ -13,7 +13,7 @@ module Transifex
         @project_slug = project_slug
       end
 
-      def self.parents
+      def self.authors
         [:project]      
       end 
     end    

--- a/lib/transifex/resource.rb
+++ b/lib/transifex/resource.rb
@@ -13,7 +13,7 @@ module Transifex
       @resource_slug = resource_slug
     end
 
-    def self.parents
+    def self.authors
       [:project]      
     end  
 

--- a/lib/transifex/resource_components/content.rb
+++ b/lib/transifex/resource_components/content.rb
@@ -12,7 +12,7 @@ module Transifex
         @project_slug = project_slug
         @resource_slug = resource_slug
       end
-      def self.parents
+      def self.authors
         [:project, :resource]      
       end
       def fetch_with_file(path_to_file = nil)

--- a/lib/transifex/resource_components/source.rb
+++ b/lib/transifex/resource_components/source.rb
@@ -15,7 +15,7 @@ module Transifex
         @resource_slug = resource_slug
         @source_slug = compute_source_entity_hash(translation_key, translation_context)
       end
-      def self.parents
+      def self.authors
         [:project, :resource]      
       end
     end

--- a/lib/transifex/resource_components/stats.rb
+++ b/lib/transifex/resource_components/stats.rb
@@ -13,7 +13,7 @@ module Transifex
         @resource_slug = resource_slug
       end
 
-      def self.parents
+      def self.authors
         [:project, :resource]      
       end 
 

--- a/lib/transifex/resource_components/translation.rb
+++ b/lib/transifex/resource_components/translation.rb
@@ -15,7 +15,7 @@ module Transifex
         @translation_slug = translation_slug
       end
 
-      def self.parents
+      def self.authors
         [:project, :resource]      
       end 
 

--- a/lib/transifex/resource_components/translation_components/string.rb
+++ b/lib/transifex/resource_components/translation_components/string.rb
@@ -20,7 +20,7 @@ module Transifex
           @string_slug = compute_source_entity_hash(translation_key, translation_context)
         end
 
-        def self.parents
+        def self.authors
           [:project, :resource, :translation]            
         end
       end

--- a/lib/transifex/resource_components/translation_components/strings.rb
+++ b/lib/transifex/resource_components/translation_components/strings.rb
@@ -21,7 +21,7 @@ module Transifex
           self.fetch(options)      
         end
 
-        def self.parents
+        def self.authors
           [:project, :resource, :translation]            
         end  
 

--- a/lib/transifex/resources.rb
+++ b/lib/transifex/resources.rb
@@ -12,7 +12,7 @@ module Transifex
       @project_slug = project_slug
     end
 
-    def self.parents
+    def self.authors
       [:project]      
     end 
   end


### PR DESCRIPTION
Rails adds a `parents` method on the Module class [here](https://github.com/rails/rails/blob/c9bbac46ddfc68caff6cd8a95c8d0fd045bd9201/activesupport/lib/active_support/core_ext/module/introspection.rb#L46) or [here](http://api.rubyonrails.org/v4.2/classes/Module.html#method-i-parents).
The gem explicitly checks if it's classes (Language, Project, Resource..) respond to the `parents` method. This would mean that it would always be true when using in Rails.