### PR TITLE
Upload translation strings

### DIFF
--- a/lib/transifex/resource_components/translation_components/strings.rb
+++ b/lib/transifex/resource_components/translation_components/strings.rb
@@ -28,8 +28,10 @@ module Transifex
         def update(params)
           params = [params] unless params.is_a?(Array)
           params.each do |param|
-            raise MissingParametersError.new(["key"]) unless param.key?(:key)
-            param[:source_entity_hash] = compute_source_entity_hash(param[:key], param[:context])
+            unless param.key?(:source_entity_hash)
+              raise(MissingParametersError, 'key') unless param.key?(:key)
+              param[:source_entity_hash] = compute_source_entity_hash(param[:key], param[:context])
+            end
           end
           super
         end 


### PR DESCRIPTION
Allow upload of translation text where we already know the string hash. Apart from there being no need to calculate the hash, Transifex doc suggests it can be a bit finicky - for example the method changes depending on the programming language you are working in. Since we have the hash we got from Transifex, there is not need to take a chance on this brittleness.